### PR TITLE
Preserve the attempted path upon failed authentication

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -80,7 +80,7 @@ class SinatraWardenExample < Sinatra::Base
   end
 
   post '/auth/unauthenticated' do
-    session[:return_to] = env['warden.options'][:attempted_path]
+    session[:return_to] = env['warden.options'][:attempted_path] if session[:return_to].nil?
     puts env['warden.options'][:attempted_path]
     puts env['warden']
     flash[:error] = env['warden'].message || "You must log in"


### PR DESCRIPTION
Modify app.rb route '/auth/unauthenticated' do ensure that the
return to path of session[:return_to] will remain even after
a failed authentication attempt.
